### PR TITLE
Remove trailing slash in Quickstart

### DIFF
--- a/examples/QUICKSTART.md
+++ b/examples/QUICKSTART.md
@@ -3,7 +3,7 @@
 package main
 
 import (
-	"github.com/HOWZ1T/space_trader/"
+	"github.com/HOWZ1T/space_trader"
 	"fmt"
 )
 


### PR DESCRIPTION
I got `src/main.go:4:2: malformed import path "github.com/HOWZ1T/space_trader/": trailing slash` when I just copy and pasted this. Works great with it removed 😄