### PR TITLE
add ability to search system flight plans

### DIFF
--- a/flight_plans.go
+++ b/flight_plans.go
@@ -51,3 +51,19 @@ func (st *SpaceTrader) GetFlightPlan(flightPlanID string) (models.FlightPlan, er
 
 	return raw["flightPlan"], nil
 }
+
+// Retrieves all flight plans witin a system
+// Note you must have an active ship in that system
+func (st *SpaceTrader) GetAllFlightPlansWithinSystem(symbol string) ([]models.CommonFlightPlan, error) {
+	uri := systems + symbol + "/flight-plans/"
+
+	var raw map[string][]models.CommonFlightPlan
+	err := st.doShaped("GET", uri, "", nil, map[string]string{
+		"token": st.token,
+	}, &raw)
+	if err != nil {
+		return []models.CommonFlightPlan{}, err
+	}
+
+	return raw["flightPlans"], nil
+}

--- a/models/flight_plan.go
+++ b/models/flight_plan.go
@@ -13,3 +13,14 @@ type FlightPlan struct {
 	TerminatedAt           time.Time `json:"terminatedAt"`
 	TimeRemainingInSeconds int       `json:"timeRemainingInSeconds"`
 }
+
+type CommonFlightPlan struct {
+	ArrivesAt              time.Time `json:"arrivesAt"`
+	CreatedAt              time.Time `json:"createdAt"`
+	From                   string    `json:"from"`
+	To                     string    `json:"to"`
+	Username               string    `json:"username"`
+	ID                     string    `json:"id"`
+	ShipType               string    `json:"shipType"`
+	ShipID                 string    `json:"shipId"`
+}

--- a/space_trader_test.go
+++ b/space_trader_test.go
@@ -368,6 +368,18 @@ func TestFlightPlan(t *testing.T) {
 		(*assert.T)(t).Errorf("event is not of the proper type")
 		break
 	}
+
+	// Get all flight plans in system and confirm our plan is one of them
+	flightPlans, err := st.GetAllFlightPlansWithinSystem("OE")
+	(*assert.T)(t).Nil(err)
+	(*assert.T)(t).NotEquals(len(flightPlans), 0)
+	foundShipIDInPlans := false
+	for _, flightPlan := range flightPlans {
+		if flightPlan.ShipID == shipID {
+			foundShipIDInPlans = true
+		}
+	}
+	(*assert.T)(t).Equals(true, foundShipIDInPlans)
 }
 
 func TestPayLoan(t *testing.T) {


### PR DESCRIPTION
Ended up writing the test as part of the flight plan test because it requires you have an active flight plan in the system to get a result back. This also allows us to confirm that the flight plan comes back successfully so it seemed to make sense.