### PR TITLE
Update models and location endpoint to handle breaking API changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.15
 require (
 	github.com/google/uuid v1.2.0
 	github.com/joho/godotenv v1.3.0
+	github.com/mitchellh/mapstructure v1.4.1
 )

--- a/locations.go
+++ b/locations.go
@@ -1,8 +1,10 @@
 package space_trader
 
 import (
-	"github.com/HOWZ1T/space_trader/models"
 	"math"
+
+	"github.com/HOWZ1T/space_trader/models"
+	"github.com/mitchellh/mapstructure"
 )
 
 // Searches the system for the given type.
@@ -27,15 +29,18 @@ func (st *SpaceTrader) SearchSystem(system string, type_ string) ([]models.Locat
 func (st *SpaceTrader) GetLocation(symbol string) (models.Location, error) {
 	uri := locations + symbol
 
-	var raw map[string]models.Location
+	var raw map[string]interface{}
 	err := st.doShaped("GET", uri, "", nil, map[string]string{
 		"token": st.token,
 	}, &raw)
 	if err != nil {
 		return models.Location{}, err
 	}
+	var loc models.Location
+	mapstructure.Decode(raw["location"], &loc)
+	mapstructure.Decode(raw["dockedShips"], &loc.DockedShips)
 
-	return raw["planet"], nil
+	return loc, nil
 }
 
 // Get all locations in the specified system.
@@ -67,7 +72,7 @@ func (st *SpaceTrader) GetMarket(symbol string) (models.Market, error) {
 		return models.Market{}, err
 	}
 
-	return raw["planet"].Market, nil
+	return raw["location"].Market, nil
 }
 
 // Gets all the systems info.

--- a/models/locations.go
+++ b/models/locations.go
@@ -8,12 +8,22 @@ type PurchaseLocation struct {
 
 // Models the Location object.
 type Location struct {
-	Name    string `json:"name"`
-	Symbol  string `json:"symbol"`
-	Type    string `json:"type"`
-	X       int    `json:"x"`
-	Y       int    `json:"y"`
-	Anomaly string `json:"anomaly"`
+	Name            string       `json:"name"`
+	Symbol          string       `json:"symbol"`
+	Type            string       `json:"type"`
+	X               int          `json:"x"`
+	Y               int          `json:"y"`
+	Anomaly         string       `json:"anomaly"`
+	AnsibleProgress int          `json:"ansibleProgress"`
+	Ships           []DockedShip `json:"ships"`
+	DockedShips     int          `json:"dockedShips"`
+}
+
+// Models the DockedShip object returned from a Location
+type DockedShip struct {
+	ID       string `json:"shipId"`
+	Username string `json:"username"`
+	Type     string `json:"shipType"`
 }
 
 // Models a Location object that has a Market.

--- a/models/market.go
+++ b/models/market.go
@@ -2,11 +2,10 @@ package models
 
 // models a sellable good.
 type Good struct {
-	Available        int      `json:"available"`
-	VolumePerUnit    int      `json:"volumePerUnit"`
-	PricePerUnit     Currency `json:"pricePerUnit"`
-	Symbol           string   `json:"symbol"`
-	QuantityAvailabe int      `json:"quantityAvailable"`
+	QuantityAvailable int      `json:"quantityAvailable"`
+	VolumePerUnit     int      `json:"volumePerUnit"`
+	PricePerUnit      Currency `json:"pricePerUnit"`
+	Symbol            string   `json:"symbol"`
 }
 
 // models a market.


### PR DESCRIPTION
This updates the Location model and relevant functions to deal with breaking API changes, such as renaming "planet" to "location" and returning "dockedShips" objects. The ships in the array (which is only populated by `/locations/symbol/ships`) doesn't use the standard ship model, so I've added a model for that as well.