### PR TITLE
Move authorization token from URL to Authz Header

### DIFF
--- a/flight_plans.go
+++ b/flight_plans.go
@@ -2,6 +2,8 @@ package space_trader
 
 import (
 	"encoding/json"
+	"fmt"
+
 	"github.com/HOWZ1T/space_trader/events"
 	"github.com/HOWZ1T/space_trader/models"
 )
@@ -22,10 +24,9 @@ func (st *SpaceTrader) CreateFlightPlan(shipID string, destination string) (mode
 
 	var raw map[string]models.FlightPlan
 	err = st.doShaped("POST", uri, string(byts), map[string]string{
-		"Content-Type": "application/json",
-	}, map[string]string{
-		"token": st.token,
-	}, &raw)
+		"Content-Type":  "application/json",
+		"Authorization": fmt.Sprintf("Bearer %s", st.token),
+	}, nil, &raw)
 	if err != nil {
 		return models.FlightPlan{}, err
 	}
@@ -42,9 +43,9 @@ func (st *SpaceTrader) GetFlightPlan(flightPlanID string) (models.FlightPlan, er
 	uri := users + st.username + "/flight-plans/" + flightPlanID
 
 	var raw map[string]models.FlightPlan
-	err := st.doShaped("GET", uri, "", nil, map[string]string{
-		"token": st.token,
-	}, &raw)
+	err := st.doShaped("GET", uri, "", map[string]string{
+		"Authorization": fmt.Sprintf("Bearer %s", st.token),
+	}, nil, &raw)
 	if err != nil {
 		return models.FlightPlan{}, err
 	}
@@ -58,9 +59,9 @@ func (st *SpaceTrader) GetAllFlightPlansWithinSystem(symbol string) ([]models.Co
 	uri := systems + symbol + "/flight-plans/"
 
 	var raw map[string][]models.CommonFlightPlan
-	err := st.doShaped("GET", uri, "", nil, map[string]string{
-		"token": st.token,
-	}, &raw)
+	err := st.doShaped("GET", uri, "", map[string]string{
+		"Authorization": fmt.Sprintf("Bearer %s", st.token),
+	}, nil, &raw)
 	if err != nil {
 		return []models.CommonFlightPlan{}, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.15
 require (
 	github.com/google/uuid v1.2.0
 	github.com/joho/godotenv v1.3.0
+	github.com/mitchellh/mapstructure v1.4.1
 )

--- a/goods.go
+++ b/goods.go
@@ -2,9 +2,11 @@ package space_trader
 
 import (
 	"encoding/json"
+	"fmt"
+	"strconv"
+
 	"github.com/HOWZ1T/space_trader/events"
 	"github.com/HOWZ1T/space_trader/models"
-	"strconv"
 )
 
 // Buys the specified good at the specified quantity for the specified ship.
@@ -23,10 +25,9 @@ func (st *SpaceTrader) BuyGood(shipID string, good string, quantity int) (models
 
 	var shipOrder models.ShipOrder
 	err = st.doShaped("POST", uri, string(byts), map[string]string{
-		"Content-Type": "application/json",
-	}, map[string]string{
-		"token": st.token,
-	}, &shipOrder)
+		"Content-Type":  "application/json",
+		"Authorization": fmt.Sprintf("Bearer %s", st.token),
+	}, nil, &shipOrder)
 	if err != nil {
 		return models.ShipOrder{}, err
 	}
@@ -51,10 +52,9 @@ func (st *SpaceTrader) SellGood(shipID string, good string, quantity int) (model
 
 	var shipOrder models.ShipOrder
 	err = st.doShaped("POST", uri, string(byts), map[string]string{
-		"Content-Type": "application/json",
-	}, map[string]string{
-		"token": st.token,
-	}, &shipOrder)
+		"Content-Type":  "application/json",
+		"Authorization": fmt.Sprintf("Bearer %s", st.token),
+	}, nil, &shipOrder)
 	if err != nil {
 		return models.ShipOrder{}, err
 	}

--- a/loans.go
+++ b/loans.go
@@ -2,10 +2,12 @@ package space_trader
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
+
 	"github.com/HOWZ1T/space_trader/errs"
 	"github.com/HOWZ1T/space_trader/events"
 	"github.com/HOWZ1T/space_trader/models"
-	"strings"
 )
 
 // Retrieves the available loans.
@@ -15,9 +17,9 @@ func (st *SpaceTrader) AvailableLoans() ([]models.Loan, error) {
 	}
 
 	var raw map[string][]models.Loan
-	err := st.doShaped("GET", loans, "", nil, map[string]string{
-		"token": st.token,
-	}, &raw)
+	err := st.doShaped("GET", loans, "", map[string]string{
+		"Authorization": fmt.Sprintf("Bearer %s", st.token),
+	}, nil, &raw)
 	if err != nil {
 		return nil, err
 	}
@@ -50,10 +52,9 @@ func (st *SpaceTrader) TakeLoan(loanType string) (models.Account, error) {
 
 	var raw map[string]models.Account
 	err = st.doShaped("POST", uri, string(byts), map[string]string{
-		"Content-Type": "application/json",
-	}, map[string]string{
-		"token": st.token,
-	}, &raw)
+		"Content-Type":  "application/json",
+		"Authorization": fmt.Sprintf("Bearer %s", st.token),
+	}, nil, &raw)
 	if err != nil {
 		return models.Account{}, err
 	}
@@ -69,9 +70,9 @@ func (st *SpaceTrader) PayLoan(loanID string) (models.Account, error) {
 	uri := users + st.username + "/loans/" + loanID
 
 	var raw map[string]models.Account
-	err := st.doShaped("PUT", uri, "", nil, map[string]string{
-		"token": st.token,
-	}, &raw)
+	err := st.doShaped("PUT", uri, "", map[string]string{
+		"Authorization": fmt.Sprintf("Bearer %s", st.token),
+	}, nil, &raw)
 	if err != nil {
 		return models.Account{}, err
 	}

--- a/locations.go
+++ b/locations.go
@@ -1,8 +1,10 @@
 package space_trader
 
 import (
-	"github.com/HOWZ1T/space_trader/models"
 	"math"
+
+	"github.com/HOWZ1T/space_trader/models"
+	"github.com/mitchellh/mapstructure"
 )
 
 // Searches the system for the given type.
@@ -27,15 +29,18 @@ func (st *SpaceTrader) SearchSystem(system string, type_ string) ([]models.Locat
 func (st *SpaceTrader) GetLocation(symbol string) (models.Location, error) {
 	uri := locations + symbol
 
-	var raw map[string]models.Location
+	var raw map[string]interface{}
 	err := st.doShaped("GET", uri, "", nil, map[string]string{
 		"token": st.token,
 	}, &raw)
 	if err != nil {
 		return models.Location{}, err
 	}
+	var loc models.Location
+	mapstructure.Decode(raw["location"], &loc)
+	mapstructure.Decode(raw["dockedShips"], &loc.DockedShips)
 
-	return raw["planet"], nil
+	return loc, nil
 }
 
 // Get all locations in the specified system.
@@ -67,7 +72,7 @@ func (st *SpaceTrader) GetMarket(symbol string) (models.Market, error) {
 		return models.Market{}, err
 	}
 
-	return raw["planet"].Market, nil
+	return raw["location"].Market, nil
 }
 
 // Gets all the systems info.

--- a/locations.go
+++ b/locations.go
@@ -1,6 +1,7 @@
 package space_trader
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/HOWZ1T/space_trader/models"
@@ -12,11 +13,12 @@ import (
 func (st *SpaceTrader) SearchSystem(system string, type_ string) ([]models.Location, error) {
 	uri := systems + system + "/locations"
 	urlParams := make(map[string]string)
-	urlParams["token"] = st.token
 	urlParams["type"] = type_
 
 	var raw map[string][]models.Location
-	err := st.doShaped("GET", uri, "", nil, urlParams, &raw)
+	err := st.doShaped("GET", uri, "", map[string]string{
+		"Authorization": fmt.Sprintf("Bearer %s", st.token),
+	}, urlParams, &raw)
 	if err != nil {
 		return nil, err
 	}
@@ -30,9 +32,9 @@ func (st *SpaceTrader) GetLocation(symbol string) (models.Location, error) {
 	uri := locations + symbol
 
 	var raw map[string]interface{}
-	err := st.doShaped("GET", uri, "", nil, map[string]string{
-		"token": st.token,
-	}, &raw)
+	err := st.doShaped("GET", uri, "", map[string]string{
+		"Authorization": fmt.Sprintf("Bearer %s", st.token),
+	}, nil, &raw)
 	if err != nil {
 		return models.Location{}, err
 	}
@@ -49,9 +51,9 @@ func (st *SpaceTrader) GetLocationsInSystem(symbol string) ([]models.Location, e
 	uri := systems + symbol + "/locations"
 
 	var raw map[string][]models.Location
-	err := st.doShaped("GET", uri, "", nil, map[string]string{
-		"token": st.token,
-	}, &raw)
+	err := st.doShaped("GET", uri, "", map[string]string{
+		"Authorization": fmt.Sprintf("Bearer %s", st.token),
+	}, nil, &raw)
 	if err != nil {
 		return nil, err
 	}
@@ -65,9 +67,9 @@ func (st *SpaceTrader) GetMarket(symbol string) (models.Market, error) {
 	uri := locations + symbol + "/marketplace"
 
 	var raw map[string]models.MarketLocation
-	err := st.doShaped("GET", uri, "", nil, map[string]string{
-		"token": st.token,
-	}, &raw)
+	err := st.doShaped("GET", uri, "", map[string]string{
+		"Authorization": fmt.Sprintf("Bearer %s", st.token),
+	}, nil, &raw)
 	if err != nil {
 		return models.Market{}, err
 	}
@@ -82,9 +84,9 @@ func (st *SpaceTrader) GetSystems() ([]models.System, error) {
 	}
 
 	var raw map[string][]models.System
-	err := st.doShaped("GET", systems, "", nil, map[string]string{
-		"token": st.token,
-	}, &raw)
+	err := st.doShaped("GET", systems, "", map[string]string{
+		"Authorization": fmt.Sprintf("Bearer %s", st.token),
+	}, nil, &raw)
 	if err != nil {
 		return nil, err
 	}

--- a/models/locations.go
+++ b/models/locations.go
@@ -8,12 +8,22 @@ type PurchaseLocation struct {
 
 // Models the Location object.
 type Location struct {
-	Name    string `json:"name"`
-	Symbol  string `json:"symbol"`
-	Type    string `json:"type"`
-	X       int    `json:"x"`
-	Y       int    `json:"y"`
-	Anomaly string `json:"anomaly"`
+	Name            string       `json:"name"`
+	Symbol          string       `json:"symbol"`
+	Type            string       `json:"type"`
+	X               int          `json:"x"`
+	Y               int          `json:"y"`
+	Anomaly         string       `json:"anomaly"`
+	AnsibleProgress int          `json:"ansibleProgress"`
+	Ships           []DockedShip `json:"ships"`
+	DockedShips     int          `json:"dockedShips"`
+}
+
+// Models the DockedShip object returned from a Location
+type DockedShip struct {
+	ID       string `json:"shipId"`
+	Username string `json:"username"`
+	Type     string `json:"shipType"`
 }
 
 // Models a Location object that has a Market.

--- a/models/market.go
+++ b/models/market.go
@@ -2,11 +2,10 @@ package models
 
 // models a sellable good.
 type Good struct {
-	Available        int      `json:"available"`
-	VolumePerUnit    int      `json:"volumePerUnit"`
-	PricePerUnit     Currency `json:"pricePerUnit"`
-	Symbol           string   `json:"symbol"`
-	QuantityAvailabe int      `json:"quantityAvailable"`
+	QuantityAvailable int      `json:"quantityAvailable"`
+	VolumePerUnit     int      `json:"volumePerUnit"`
+	PricePerUnit      Currency `json:"pricePerUnit"`
+	Symbol            string   `json:"symbol"`
 }
 
 // models a market.

--- a/ships.go
+++ b/ships.go
@@ -2,10 +2,12 @@ package space_trader
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
+
 	"github.com/HOWZ1T/space_trader/errs"
 	"github.com/HOWZ1T/space_trader/events"
 	"github.com/HOWZ1T/space_trader/models"
-	"strings"
 )
 
 // Retrieves the available ships.
@@ -42,7 +44,6 @@ func (st *SpaceTrader) AvailableShips(class string) ([]models.Ship, error) {
 	}
 
 	urlParams := make(map[string]string)
-	urlParams["token"] = st.token
 
 	if class != "" {
 		class = strings.Trim(class, "\r\n")
@@ -60,7 +61,9 @@ func (st *SpaceTrader) AvailableShips(class string) ([]models.Ship, error) {
 	}
 
 	var raw map[string][]models.Ship
-	err := st.doShaped("GET", ships, "", nil, urlParams, &raw)
+	err := st.doShaped("GET", ships, "", map[string]string{
+		"Authorization": fmt.Sprintf("Bearer %s", st.token),
+	}, urlParams, &raw)
 	if err != nil {
 		return nil, err
 	}
@@ -84,11 +87,10 @@ func (st *SpaceTrader) BuyShip(location string, shipType string) (models.Account
 
 	var raw map[string]models.Account
 	err = st.doShaped("POST", uri, string(byts), map[string]string{
-		"Content-Type": "application/json",
-		"Accept":       "application/json",
-	}, map[string]string{
-		"token": st.token,
-	}, &raw)
+		"Content-Type":  "application/json",
+		"Accept":        "application/json",
+		"Authorization": fmt.Sprintf("Bearer %s", st.token),
+	}, nil, &raw)
 	if err != nil {
 		return models.Account{}, err
 	}

--- a/user.go
+++ b/user.go
@@ -1,6 +1,8 @@
 package space_trader
 
 import (
+	"fmt"
+
 	"github.com/HOWZ1T/space_trader/errs"
 	"github.com/HOWZ1T/space_trader/events"
 	"github.com/HOWZ1T/space_trader/models"
@@ -44,9 +46,9 @@ func (st *SpaceTrader) Account() (models.Account, error) {
 
 	uri := users + st.username
 	var raw map[string]models.Account
-	err := st.doShaped("GET", uri, "", nil, map[string]string{
-		"token": st.token,
-	}, &raw)
+	err := st.doShaped("GET", uri, "", map[string]string{
+		"Authorization": fmt.Sprintf("Bearer %s", st.token),
+	}, nil, &raw)
 	if err != nil {
 		return models.Account{}, err
 	}
@@ -64,9 +66,9 @@ func (st *SpaceTrader) MyLoans() ([]models.Loan, error) {
 	uri := users + st.username + "/loans"
 
 	var raw map[string][]models.Loan
-	err := st.doShaped("GET", uri, "", nil, map[string]string{
-		"token": st.token,
-	}, &raw)
+	err := st.doShaped("GET", uri, "", map[string]string{
+		"Authorization": fmt.Sprintf("Bearer %s", st.token),
+	}, nil, &raw)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This moves the API key to the `Authorization` HTTP header instead of passing it in the URL, which had some security implications.